### PR TITLE
chore: add .gitignore for Rust artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target
+Cargo.lock
+*.wasm
+*.optimized.wasm
+.env
+.env.*


### PR DESCRIPTION
Fixes #64

## Summary
- add a minimal .gitignore for Rust/Cargo build artifacts
- ignore Cargo.lock for this library repo
- ignore wasm outputs and local .env files