### PR TITLE
fix: add transaction count getter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,11 @@ impl RemittanceContract {
             .unwrap_or(0)
     }
 
+    /// Read the current transaction count.
+    pub fn tx_count(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::TxCount).unwrap_or(0)
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     fn next_id(env: &Env) -> u64 {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -72,6 +72,26 @@ fn test_escrow_and_release() {
 }
 
 #[test]
+fn test_tx_count() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.init(&admin);
+    client.deposit(&sender, &10);
+
+    assert_eq!(client.tx_count(), 0);
+
+    let first_tx_id = client.send(&sender, &recipient, &1);
+    assert_eq!(first_tx_id, 1);
+    assert_eq!(client.tx_count(), 1);
+
+    let second_tx_id = client.escrow_funds(&sender, &recipient, &1);
+    assert_eq!(second_tx_id, 2);
+    assert_eq!(client.tx_count(), 2);
+}
+
+#[test]
 #[should_panic(expected = "not in escrow")]
 fn test_double_release_fails() {
     let (env, client) = setup();


### PR DESCRIPTION
Fixes #49

## Summary
- add a tx_count getter that reads the current transaction count from instance storage
- add focused coverage for the transaction count behavior
- allow integration tests to import the crate by including rlib in crate-type