### PR TITLE
docs: document persistent vs instance storage distinction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ impl RemittanceContract {
     /// Initialize contract with an admin address for the remmittanceContract.
     pub fn init(env: Env, admin: Address) {
         admin.require_auth();
+        // Admin and TxCount use instance() storage: they are contract-scoped singletons
+        // that share the contract instance's ledger entry and are evicted together.
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TxCount, &0u64);
     }
@@ -27,6 +29,8 @@ impl RemittanceContract {
         const MIN_DEPOSIT: i128 = 1_000_000; // Minimum deposit amount (0.000001 XLM equivalent)
         assert!(amount >= MIN_DEPOSIT, "amount below minimum deposit threshold");
         
+        // Balance uses persistent() storage: per-address data must survive
+        // beyond the contract instance's TTL and be independently renewable.
         let key = DataKey::Balance(sender.clone());
         let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         
@@ -50,6 +54,7 @@ impl RemittanceContract {
         sender.require_auth();
         assert!(amount > 0, "Send amount must be greater than zero");
 
+        // Balance keys use persistent() storage so user funds survive instance eviction.
         let sender_key = DataKey::Balance(sender.clone());
         let sender_bal: i128 = env.storage().persistent().get(&sender_key).unwrap_or(0);
         assert!(sender_bal >= amount, "insufficient balance");
@@ -71,6 +76,7 @@ impl RemittanceContract {
             status: TransactionStatus::Completed,
             timestamp,
         };
+        // Transaction uses persistent() storage so records are durable and queryable long-term.
         env.storage().persistent().set(&DataKey::Transaction(id), &tx);
 
         env.events().publish(
@@ -89,6 +95,7 @@ impl RemittanceContract {
         sender.require_auth();
         assert!(amount > 0, "Escrow amount must be greater than zero");
 
+        // Balance uses persistent() storage so escrowed funds are durably tracked.
         let sender_key = DataKey::Balance(sender.clone());
         let sender_bal: i128 = env.storage().persistent().get(&sender_key).unwrap_or(0);
         assert!(sender_bal >= amount, "insufficient balance");
@@ -116,6 +123,7 @@ impl RemittanceContract {
 
     /// Release escrowed funds to recipient.
     pub fn release_escrow(env: Env, transaction_id: u64) {
+        // Transaction uses persistent() storage — load the durable record by ID.
         let key = DataKey::Transaction(transaction_id);
         let mut tx: Transaction = env
             .storage()
@@ -178,6 +186,8 @@ impl RemittanceContract {
     // ──__________________ helpers ________________________
 
     fn next_id(env: &Env) -> u64 {
+        // TxCount uses instance() storage: it is a contract-scoped counter that
+        // lives and expires with the contract instance.
         let count: u64 = env
             .storage()
             .instance()


### PR DESCRIPTION
## Summary

Resolves #19.

`DataKey::Balance` and `DataKey::Transaction` use `env.storage().persistent()` — per-address balances and transaction records must survive beyond the contract instance's TTL and be independently renewable on-chain.

`DataKey::Admin` and `DataKey::TxCount` use `env.storage().instance()` — they are contract-scoped singletons that share the instance ledger entry and are evicted together with the contract.

## Changes

- Added inline comments at every `persistent()` and `instance()` call site in `src/lib.rs` explaining the rationale for each storage type choice.
- No logic changes; comments only.

## Testing

Changes are documentation-only (comments). Existing tests continue to cover all logic paths unchanged.

Closes #19