### PR TITLE
fix: persistent storage comments, escrow expiry logic, and expiry test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ impl RemittanceContract {
         assert!(amount >= MIN_DEPOSIT, "amount below minimum deposit threshold");
         
         let key = DataKey::Balance(sender.clone());
+        // Balance uses persistent storage — survives ledger expiry
         let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         
         // Overflow protection
@@ -51,6 +52,7 @@ impl RemittanceContract {
         assert!(amount > 0, "Send amount must be greater than zero");
 
         let sender_key = DataKey::Balance(sender.clone());
+        // Balance uses persistent storage — survives ledger expiry
         let sender_bal: i128 = env.storage().persistent().get(&sender_key).unwrap_or(0);
         assert!(sender_bal >= amount, "insufficient balance");
 
@@ -70,7 +72,9 @@ impl RemittanceContract {
             amount,
             status: TransactionStatus::Completed,
             timestamp,
+            expires_at: 0,
         };
+        // Transaction uses persistent storage — survives ledger expiry
         env.storage().persistent().set(&DataKey::Transaction(id), &tx);
 
         env.events().publish(
@@ -85,10 +89,12 @@ impl RemittanceContract {
     }
 
     /// Lock funds in escrow pending release.
-    pub fn escrow_funds(env: Env, sender: Address, recipient: Address, amount: i128) -> u64 {
+    /// `expiry_ledgers`: number of ledgers until escrow expires (0 = no expiry).
+    pub fn escrow_funds(env: Env, sender: Address, recipient: Address, amount: i128, expiry_ledgers: u32) -> u64 {
         sender.require_auth();
         assert!(amount > 0, "Escrow amount must be greater than zero");
 
+        // Balance uses persistent storage — survives ledger expiry
         let sender_key = DataKey::Balance(sender.clone());
         let sender_bal: i128 = env.storage().persistent().get(&sender_key).unwrap_or(0);
         assert!(sender_bal >= amount, "insufficient balance");
@@ -97,6 +103,11 @@ impl RemittanceContract {
 
         let id = Self::next_id(&env);
         let timestamp = env.ledger().timestamp();
+        let expires_at = if expiry_ledgers > 0 {
+            u64::from(env.ledger().sequence()) + u64::from(expiry_ledgers)
+        } else {
+            0
+        };
         let tx = Transaction {
             id,
             sender: sender.clone(),
@@ -104,7 +115,9 @@ impl RemittanceContract {
             amount,
             status: TransactionStatus::Escrowed,
             timestamp,
+            expires_at,
         };
+        // Transaction uses persistent storage — survives ledger expiry
         env.storage().persistent().set(&DataKey::Transaction(id), &tx);
 
         env.events().publish(
@@ -116,6 +129,7 @@ impl RemittanceContract {
 
     /// Release escrowed funds to recipient.
     pub fn release_escrow(env: Env, transaction_id: u64) {
+        // Transaction uses persistent storage — survives ledger expiry
         let key = DataKey::Transaction(transaction_id);
         let mut tx: Transaction = env
             .storage()
@@ -128,8 +142,17 @@ impl RemittanceContract {
             "not in escrow"
         );
 
+        // Expiry check: if expires_at is set, current ledger must not exceed it
+        if tx.expires_at > 0 {
+            assert!(
+                u64::from(env.ledger().sequence()) <= tx.expires_at,
+                "escrow expired"
+            );
+        }
+
         tx.sender.require_auth();
 
+        // Balance uses persistent storage — survives ledger expiry
         let recipient_key = DataKey::Balance(tx.recipient.clone());
         let recipient_bal: i128 = env.storage().persistent().get(&recipient_key).unwrap_or(0);
         assert!(recipient_bal <= i128::MAX - tx.amount, "balance overflow detected");

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,8 @@ pub struct Transaction {
     pub amount: i128,
     pub status: TransactionStatus,
     pub timestamp: u64,
+    /// Ledger sequence number after which this escrow expires (0 = no expiry)
+    pub expires_at: u64,
 }
 
 #[contracttype]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::{Address as _, Events as _}, Address, Env, IntoVal, Symbol};
+use soroban_sdk::{testutils::{Address as _, Events as _, Ledger as _}, Address, Env, IntoVal, Symbol};
 use stellarremit_contract::{RemittanceContract, RemittanceContractClient};
 
 fn setup() -> (Env, RemittanceContractClient<'static>) {
@@ -72,7 +72,7 @@ fn test_escrow_insufficient_balance() {
     let recipient = Address::generate(&env);
     client.init(&admin);
     client.deposit(&sender, &1_000_000);
-    client.escrow_funds(&sender, &recipient, &5_000_000); // should panic
+    client.escrow_funds(&sender, &recipient, &5_000_000, &0); // should panic
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn test_escrow_and_release() {
     let recipient = Address::generate(&env);
     client.init(&admin);
     client.deposit(&sender, &1_000_000);
-    let tx_id = client.escrow_funds(&sender, &recipient, &400_000);
+    let tx_id = client.escrow_funds(&sender, &recipient, &400_000, &0);
     // funds deducted from sender, not yet at recipient
     assert_eq!(client.balance(&sender), 600_000);
     assert_eq!(client.balance(&recipient), 0);
@@ -106,7 +106,7 @@ fn test_tx_count() {
     assert_eq!(first_tx_id, 1);
     assert_eq!(client.tx_count(), 1);
 
-    let second_tx_id = client.escrow_funds(&sender, &recipient, &1_000_000);
+    let second_tx_id = client.escrow_funds(&sender, &recipient, &1_000_000, &0);
     assert_eq!(second_tx_id, 2);
     assert_eq!(client.tx_count(), 2);
 }
@@ -120,7 +120,7 @@ fn test_double_release_fails() {
     let recipient = Address::generate(&env);
     client.init(&admin);
     client.deposit(&sender, &1_000_000);
-    let tx_id = client.escrow_funds(&sender, &recipient, &400_000);
+    let tx_id = client.escrow_funds(&sender, &recipient, &400_000, &0);
     client.release_escrow(&tx_id);
     client.release_escrow(&tx_id); // should panic
 }
@@ -134,7 +134,7 @@ fn test_escrow_funds_emits_transfer_created_event() {
     client.init(&admin);
     client.deposit(&sender, &1_000_000);
 
-    let tx_id = client.escrow_funds(&sender, &recipient, &400_000);
+    let tx_id = client.escrow_funds(&sender, &recipient, &400_000, &0);
 
     // deposit emits 1 event; escrow_funds emits 1 event — check the last one
     let events = env.events().all();
@@ -166,18 +166,60 @@ fn test_release_escrow_emits_transfer_completed_event() {
     client.init(&admin);
     client.deposit(&sender, &1_000_000);
 
-    let tx_id = client.escrow_funds(&sender, &recipient, &400_000);
+    let tx_id = client.escrow_funds(&sender, &recipient, &400_000, &0);
     client.release_escrow(&tx_id);
 
     let events = env.events().all();
     assert_eq!(events.len(), 3);
     assert_eq!(
-        events[2],
-        (
-            client.address.clone(),
-            (Symbol::new(&env, "transfer_completed"), sender.clone()).into_val(&env),
-            (tx_id, recipient.clone()).into_val(&env),
-        )
+        events,
+        soroban_sdk::vec![
+            &env,
+            (
+                client.address.clone(),
+                (Symbol::new(&env, "deposit"), sender.clone()).into_val(&env),
+                (1_000_000i128, 1_000_000i128).into_val(&env),
+            ),
+            (
+                client.address.clone(),
+                (Symbol::new(&env, "transfer_created"), sender.clone()).into_val(&env),
+                (tx_id, 400_000i128).into_val(&env),
+            ),
+            (
+                client.address.clone(),
+                (Symbol::new(&env, "transfer_completed"), sender.clone()).into_val(&env),
+                (tx_id, recipient.clone()).into_val(&env),
+            ),
+        ]
     );
 }
 
+
+#[test]
+#[should_panic(expected = "escrow expired")]
+fn test_escrow_expiry_prevents_release() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.init(&admin);
+    client.deposit(&sender, &1_000_000);
+
+    // Create escrow that expires after 10 ledgers
+    let tx_id = client.escrow_funds(&sender, &recipient, &400_000, &10);
+
+    // Advance ledger sequence past expiry
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: env.ledger().timestamp(),
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: env.ledger().sequence() + 11,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3110400,
+    });
+
+    // Should panic: escrow expired
+    client.release_escrow(&tx_id);
+}


### PR DESCRIPTION
## Summary

Resolves all issues assigned to Blaqkenny.

### Issue #19 — Use persistent storage for balances and transactions
Added inline code comments in `lib.rs` explicitly documenting that `DataKey::Balance` and `DataKey::Transaction` use `env.storage().persistent()`, while `DataKey::Admin` and `DataKey::TxCount` use `env.storage().instance()`.

### Issue #46 — Add expiry logic to escrow (dependency of #69)
- Added `expires_at: u64` field to `Transaction` struct in `types.rs`
- `escrow_funds` now accepts an `expiry_ledgers: u32` parameter; sets `expires_at = current_sequence + expiry_ledgers` (0 means no expiry)
- `release_escrow` asserts `ledger.sequence() <= expires_at` when expiry is set, panicking with `"escrow expired"`

### Issue #69 — Write unit test: test_escrow_expiry_prevents_release
Added `test_escrow_expiry_prevents_release` in `tests/integration_test.rs`:
- Creates an escrow with a 10-ledger expiry
- Advances the ledger sequence past expiry using `env.ledger().set()`
- Calls `release_escrow` and expects a panic with `"escrow expired"`

## Tests
All 13 tests pass (`cargo test`).

Closes #19
Closes #46
Closes #69