### PR TITLE
fix: prevent re-initialization of contract

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ pub struct RemittanceContract;
 impl RemittanceContract {
     /// Initialize contract with an admin address for the remmittanceContract.
     pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
         admin.require_auth();
         // Admin and TxCount use instance() storage: they are contract-scoped singletons
         // that share the contract instance's ledger entry and are evicted together.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,6 +19,15 @@ fn test_init() {
 }
 
 #[test]
+#[should_panic(expected = "already initialized")]
+fn test_init_twice_panics() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    client.init(&admin); // should panic
+}
+
+#[test]
 fn test_get_admin() {
     let (env, client) = setup();
     let admin = Address::generate(&env);


### PR DESCRIPTION
## Summary

Resolves #20 — adds a re-initialization guard to `init()` to prevent admin takeover after deployment.

## Changes

**`src/lib.rs`**
- Added a check at the top of `init()` using `env.storage().instance().has(&DataKey::Admin)`
- Panics with `"already initialized"` if the contract has already been initialized

**`tests/integration_test.rs`**
- Added `test_init_twice_panics` test that verifies calling `init()` a second time panics with the expected message

## Security Impact

Without this guard, any caller could invoke `init()` again after deployment and overwrite the admin address, taking full control of the contract. This fix closes that attack vector.

Closes #20