### PR TITLE
fix: overflow protection, transfer_admin, and README bindings (closes #67, #61, #68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,40 @@ bash deploy.sh
 
 ---
 
+## Generating TypeScript Bindings
+
+For frontend integration, generate TypeScript bindings from the deployed contract:
+
+```bash
+# Install the soroban CLI bindings plugin
+cargo install --locked soroban-cli
+
+# Generate bindings for your deployed contract
+soroban contract bindings typescript \
+  --contract-id <CONTRACT_ID> \
+  --output-dir ./bindings \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015"
+```
+
+The generated bindings include typed methods for all contract functions, making it easy to integrate with React, Next.js, or any TypeScript frontend.
+
+```typescript
+// Example: using generated bindings in a TypeScript project
+import { Client as RemittanceClient } from './bindings';
+
+const client = new RemittanceClient({
+  contractId: '<CONTRACT_ID>',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+});
+
+// Now call contract functions with full type safety
+const balance = await client.balance({ addr: userPublicKey });
+```
+
+---
+
 ## CLI Interactions
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,7 @@ impl RemittanceContract {
         let key = DataKey::Balance(sender.clone());
         // Balance uses persistent storage — survives ledger expiry
         let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        
-        // Overflow protection
-        assert!(balance <= i128::MAX - amount, "balance overflow detected");
-        
-        let new_balance = balance + amount;
+        let new_balance = balance.checked_add(amount).expect("arithmetic overflow");
         env.storage().persistent().set(&key, &new_balance);
         
         // Emit deposit event for tracking
@@ -68,10 +64,13 @@ impl RemittanceContract {
 
         let recipient_key = DataKey::Balance(recipient.clone());
         let recipient_bal: i128 = env.storage().persistent().get(&recipient_key).unwrap_or(0);
-        assert!(recipient_bal <= i128::MAX - amount, "balance overflow detected");
 
-        env.storage().persistent().set(&sender_key, &(sender_bal - amount));
-        env.storage().persistent().set(&recipient_key, &(recipient_bal + amount));
+        env.storage()
+            .persistent()
+            .set(&sender_key, &sender_bal.checked_sub(amount).expect("arithmetic overflow"));
+        env.storage()
+            .persistent()
+            .set(&recipient_key, &recipient_bal.checked_add(amount).expect("arithmetic overflow"));
 
         let id = Self::next_id(&env);
         let timestamp = env.ledger().timestamp();
@@ -109,7 +108,9 @@ impl RemittanceContract {
         let sender_bal: i128 = env.storage().persistent().get(&sender_key).unwrap_or(0);
         assert!(sender_bal >= amount, "insufficient balance");
 
-        env.storage().persistent().set(&sender_key, &(sender_bal - amount));
+        env.storage()
+            .persistent()
+            .set(&sender_key, &sender_bal.checked_sub(amount).expect("arithmetic overflow"));
 
         let id = Self::next_id(&env);
         let timestamp = env.ledger().timestamp();
@@ -165,10 +166,9 @@ impl RemittanceContract {
         // Balance uses persistent storage — survives ledger expiry
         let recipient_key = DataKey::Balance(tx.recipient.clone());
         let recipient_bal: i128 = env.storage().persistent().get(&recipient_key).unwrap_or(0);
-        assert!(recipient_bal <= i128::MAX - tx.amount, "balance overflow detected");
         env.storage()
             .persistent()
-            .set(&recipient_key, &(recipient_bal + tx.amount));
+            .set(&recipient_key, &recipient_bal.checked_add(tx.amount).expect("arithmetic overflow"));
 
         tx.status = TransactionStatus::Released;
         env.storage().persistent().set(&key, &tx);
@@ -185,6 +185,30 @@ impl RemittanceContract {
             .instance()
             .get(&DataKey::Admin)
             .expect("admin not initialized")
+    }
+
+    /// Transfer admin rights to a new address.
+    /// Requires authentication from the current admin.
+    /// Emits an admin_transferred event.
+    pub fn transfer_admin(env: Env, new_admin: Address) {
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("admin not initialized");
+        current_admin.require_auth();
+
+        assert!(
+            new_admin != current_admin,
+            "new admin must differ from current admin"
+        );
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin_transferred"), current_admin),
+            new_admin,
+        );
     }
 
     /// Read a transaction by ID...

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -269,6 +269,36 @@ fn test_escrow_zero_amount_fails() {
 }
 
 #[test]
+fn test_transfer_admin() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.init(&admin);
+
+    assert_eq!(client.get_admin(), admin);
+
+    client.transfer_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+
+    // Verify admin_transferred event was emitted
+    let events = env.events().all();
+    let admin_transferred = events.iter().find(|(_, topics, _)| {
+        *topics
+            == soroban_sdk::vec![
+                &env,
+                soroban_sdk::Symbol::new(&env, "admin_transferred").into_val(&env),
+                admin.clone().into_val(&env),
+            ]
+    });
+    assert!(admin_transferred.is_some(), "admin_transferred event not emitted");
+
+    let (_, _, data) = admin_transferred.unwrap();
+    let emitted_admin: Address = data.into_val(&env);
+    assert_eq!(emitted_admin, new_admin);
+}
+
+#[test]
 #[should_panic(expected = "transaction not found")]
 fn test_get_transaction_not_found_panics() {
     let (env, client) = setup();


### PR DESCRIPTION
## Summary

Fixes three open issues:

### #67 - Add overflow protection for balance arithmetic
- Replaced raw `+` and `-` on i128 balances with `checked_add`/`checked_sub`
- Panics with "arithmetic overflow" on overflow
- Applied to `deposit`, `send`, `escrow_funds`, and `release_escrow`
- Removed redundant pre-check assertions

### #61 - Add admin transfer function: transfer_admin()
- Added `transfer_admin(new_admin)` requiring current admin auth
- Validates new admin differs from current admin
- Updates `DataKey::Admin` to the new address
- Emits `admin_transferred` event
- Includes `test_transfer_admin()` test (closes #62)

### #68 - Add soroban contract bindings generation to README
- Added "Generating TypeScript Bindings" section
- Shows CLI command and TypeScript integration example

## Commits
- `4591824` fix: add overflow protection with checked_add/checked_sub (closes #67)
- `edb91eb` feat: add transfer_admin() function and test (closes #61, closes #62)
- `a5c5481` docs: add TypeScript bindings generation to README (closes #68)
closes #61 
closes #67 
closes #68 