### PR TITLE
fix: correct cargo fmt - mixed formatting for nested extend_ttl by line width

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,9 +538,11 @@ impl RemittanceContract {
                     // Extend Balance for sender
                     let sender_bal_key = DataKey::Balance(tx.sender.clone());
                     if env.storage().persistent().has(&sender_bal_key) {
-                        env.storage()
-                            .persistent()
-                            .extend_ttl(&sender_bal_key, threshold, threshold);
+                        env.storage().persistent().extend_ttl(
+                            &sender_bal_key,
+                            threshold,
+                            threshold,
+                        );
                     }
                     // Extend Balance for recipient
                     let rec_bal_key = DataKey::Balance(tx.recipient.clone());
@@ -552,9 +554,11 @@ impl RemittanceContract {
                     // Extend UserMetadata for sender
                     let sender_meta_key = DataKey::UserMetadata(tx.sender.clone());
                     if env.storage().persistent().has(&sender_meta_key) {
-                        env.storage()
-                            .persistent()
-                            .extend_ttl(&sender_meta_key, threshold, threshold);
+                        env.storage().persistent().extend_ttl(
+                            &sender_meta_key,
+                            threshold,
+                            threshold,
+                        );
                     }
                     // Extend UserMetadata for recipient
                     let rec_meta_key = DataKey::UserMetadata(tx.recipient);


### PR DESCRIPTION
sender_bal_key (103 chars) and sender_meta_key (103 chars) exceed 100-char limit → use broken-args style. rec_bal_key and rec_meta_key fit at exactly 100 chars → use chain style.