### PR TITLE
fix: resolve clippy errors, bump version, update SECURITY.md admin lists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,9 +18,9 @@ We aim to acknowledge reports within 48 hours and provide a fix within 7 days.
 ## Security Model
 
 ### Authorization
-- **Admin-only functions:** `init`, `transfer_admin`, `pause`, `unpause`, `withdraw`, `set_fee`, `set_rate_limit`, `extend_ttl`
-- **User-authenticated:** `deposit`, `send`, `escrow_funds`, `release_escrow`, `cancel_escrow`, `set_user_metadata`
-- **Public reads:** `balance`, `get_transaction`, `get_admin`, `is_paused`, `total_supply`, `tx_count`, `get_fee`, `get_rate_limit`, `get_user_metadata`, `version`, `stats`
+- **Admin-only functions:** `init`, `transfer_admin`, `pause`, `unpause`, `withdraw`, `set_fee`, `set_rate_limit`, `extend_ttl`, `batch_deposit`, `collect_fees`, `admin_release_escrow`, `admin_cancel_escrow`, `record_upgrade`, `set_daily_limit`, `add_admin`, `remove_admin`, `set_approval_threshold`
+- **User-authenticated:** `deposit`, `send`, `escrow_funds`, `release_escrow`, `cancel_escrow`, `set_user_metadata`, `confirm_escrow`
+- **Public reads:** `balance`, `get_transaction`, `transaction_exists`, `get_admin`, `is_paused`, `total_supply`, `tx_count`, `get_fee`, `get_rate_limit`, `get_user_metadata`, `version`, `stats`, `get_transactions_page`, `query_user_transactions`, `is_escrow_confirmed`, `get_upgrade_info`, `get_daily_limit`, `get_admin_set`, `get_approval_threshold`
 
 ### Overflow Protection
 All balance arithmetic uses `checked_add` / `checked_sub` with explicit panic on overflow. No raw `+` or `-` operators on user balances.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,7 @@ impl RemittanceContract {
 
     /// Return the contract version string.
     pub fn version(env: Env) -> soroban_sdk::String {
-        soroban_sdk::String::from_str(&env, "1.2.0")
+        soroban_sdk::String::from_str(&env, "1.3.0")
     }
 
     /// Return aggregate contract statistics in a single call.
@@ -1030,7 +1030,7 @@ impl RemittanceContract {
     pub fn remove_admin(env: Env, admin_to_remove: Address) {
         Self::require_admin(&env);
 
-        let mut admins: soroban_sdk::Vec<Address> = env
+        let admins: soroban_sdk::Vec<Address> = env
             .storage()
             .instance()
             .get(&DataKey::AdminSet)
@@ -1147,13 +1147,13 @@ impl RemittanceContract {
             return;
         }
 
-        let ledger_day = env.ledger().sequence() / 17280; // ~24h of ledgers
+        let ledger_day = u64::from(env.ledger().sequence()) / 17280; // ~24h of ledgers
         let volume_key = DataKey::DailyVolume(addr.clone());
         let (stored_day, current_volume): (u64, i128) = env
             .storage()
             .persistent()
             .get(&volume_key)
-            .unwrap_or((ledger_day, 0i128));
+            .unwrap_or((0u64, 0i128));
 
         let effective_volume = if stored_day == ledger_day {
             current_volume


### PR DESCRIPTION
Fixes CI failures from #119:
- Fixed type mismatch in check_daily_volume (u32 vs u64)
- Removed unused `mut` on admins in remove_admin
- Bumped version() from 1.2.0 to 1.3.0 to match CHANGELOG
- Updated SECURITY.md admin/user/public read function lists